### PR TITLE
Switch database provider from PostgreSQL to MySQL

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = "mysql"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
Updated Prisma schema to use MySQL as the database provider instead of PostgreSQL.